### PR TITLE
URIEncoderDecoder encoding UTF-8 was UTF8 gwt fix

### DIFF
--- a/src/main/java/walkingkooka/j2cl/java/net/URIEncoderDecoder.java
+++ b/src/main/java/walkingkooka/j2cl/java/net/URIEncoderDecoder.java
@@ -30,7 +30,9 @@ class URIEncoderDecoder {
 
     static final String digits = "0123456789ABCDEF"; //$NON-NLS-1$
 
-    static final String encoding = "UTF8"; //$NON-NLS-1$
+    // when UTF8
+    // GWT throws java.io.UnsupportedEncodingException: UTF8
+    static final String encoding = "UTF-8"; //$NON-NLS-1$
 
     /**
      * Validate a string by checking if it contains any characters other than:


### PR DESCRIPTION
- In a browser: URI.getFragment throws java.io.UnsupportedEncodingException: UTF8.

- Closes https://github.com/mP1/walkingkooka-spreadsheet-dominokit/issues/663
- Uncaught Error: java.lang.RuntimeException: java.io.UnsupportedEncodingException: UTF8